### PR TITLE
Update fc mock adapter ids

### DIFF
--- a/mockups/DL325_Gen10Plus_FC/Chassis/1/NetworkAdapters/DE081000/NetworkDeviceFunctions/1/Settings/index.json
+++ b/mockups/DL325_Gen10Plus_FC/Chassis/1/NetworkAdapters/DE081000/NetworkDeviceFunctions/1/Settings/index.json
@@ -65,10 +65,10 @@
                 "WWPN": null
             }
         ],
-        "PermanentWWNN": "51:40:2E:C0:18:22:21:A9",
-        "PermanentWWPN": "51:40:2E:C0:18:22:21:A8",
-        "WWNN": "51:40:2E:C0:18:22:21:A9",
-        "WWPN": "51:40:2E:C0:18:22:21:A8"
+        "PermanentWWNN": "51:40:2E:C0:18:22:21:01",
+        "PermanentWWPN": "51:40:2E:C0:18:22:21:02",
+        "WWNN": "51:40:2E:C0:18:22:21:01",
+        "WWPN": "51:40:2E:C0:18:22:21:02"
     },
     "Links": {
         "PhysicalPortAssignment": {

--- a/mockups/DL325_Gen10Plus_FC/Chassis/1/NetworkAdapters/DE081000/NetworkDeviceFunctions/1/index.json
+++ b/mockups/DL325_Gen10Plus_FC/Chassis/1/NetworkAdapters/DE081000/NetworkDeviceFunctions/1/index.json
@@ -65,10 +65,10 @@
                 "WWPN": null
             }
         ],
-        "PermanentWWNN": "51:40:2E:C0:18:22:21:A9",
-        "PermanentWWPN": "51:40:2E:C0:18:22:21:A8",
-        "WWNN": "51:40:2E:C0:18:22:21:A9",
-        "WWPN": "51:40:2E:C0:18:22:21:A8"
+        "PermanentWWNN": "51:40:2E:C0:18:22:21:01",
+        "PermanentWWPN": "51:40:2E:C0:18:22:21:02",
+        "WWNN": "51:40:2E:C0:18:22:21:01",
+        "WWPN": "51:40:2E:C0:18:22:21:02"
     },
     "Links": {
         "PhysicalPortAssignment": {


### PR DESCRIPTION
In order to make the DL325_Gen10Plus_FC mockup work with the 10.152.2.100 alletra we need to update the WWNN/WWPN returned in the mockup. We've created a host/host set in the alletra using the values in this PR. Without this update we cannot create volume using the mocked up server, it fails with:
```
[2025-09-19 19:51:56,361] [http-nio-8080-exec-4] ERROR c.m.i.StorageVolumesController - error saving volume: message=Failed to execute tcl command '{createhost -os {HVM Host} -persona 2 HPE_VM_651fd68384bc8660 51:40:2E:C0:18:22:21:A8 51:40:2E:C0:18:22:21:AA}': Host wwn 51402EC0182221A8 already used by host HPE_VM_8423a480176a40a3 (id = 3), statusCode=542, errorCode=TCL_COMMAND_FAIL 
``` 