### PR TITLE
Apply pending BIOS settings on emulated system restart

### DIFF
--- a/src/api_emulator/redfish/bios_settings_api.py
+++ b/src/api_emulator/redfish/bios_settings_api.py
@@ -37,6 +37,7 @@ Dynamic resources:
 """
 
 import sys, traceback
+import copy
 import logging
 import json_merge_patch
 from flask import request
@@ -125,3 +126,44 @@ def CreateBiosSettings(sys_id, config):
         traceback.print_exc()
         resp = simple_error_response('Server encountered an unexpected Error', 500)
     return resp
+
+
+def apply_pending_bios_settings(sys_id):
+    """
+    Emulates the BIOS applying its pending (staged) settings during POST.
+
+    Called when an emulated system restart/power-on completes. Merges the
+    pending Attributes from Bios/Settings into the live Bios resource, then
+    clears the pending settings by resyncing Bios/Settings' Attributes to
+    match the newly-applied current values. This mirrors real hardware
+    behavior, where the Settings resource is left in a diff-free state
+    after a successful apply so it does not silently re-apply on a later
+    reboot.
+    """
+    logging.info('apply_pending_bios_settings called for Systems/%s' % sys_id)
+    try:
+        if sys_id not in members:
+            return
+        pending_attrs = members[sys_id].get('Attributes')
+        if not pending_attrs:
+            return
+
+        # Imported lazily to avoid a hard import-time dependency between
+        # these two modules; resourceManager is only populated at runtime
+        # once the ResourceManager has finished initializing.
+        from . import redfish_api
+        current_bios = redfish_api.resourceManager.get_resource('Systems/%s/bios' % sys_id)
+        if 'Attributes' not in current_bios:
+            return
+
+        current_bios['Attributes'].update(pending_attrs)
+
+        # Clear the pending settings so they don't re-apply on the next boot.
+        members[sys_id]['Attributes'] = copy.deepcopy(current_bios['Attributes'])
+        settings_meta = members[sys_id].get('@Redfish.Settings')
+        if settings_meta is not None:
+            settings_meta['Messages'] = [{'MessageId': 'Base.1.0.Success'}]
+
+        logging.info('Applied pending BIOS settings for Systems/%s' % sys_id)
+    except Exception:
+        traceback.print_exc()

--- a/src/api_emulator/redfish/computer_system_api.py
+++ b/src/api_emulator/redfish/computer_system_api.py
@@ -50,6 +50,7 @@ import g
 from .redfish_auth import auth, Privilege
 from .event_generator import GenEvent, GenEventRecord
 from .event_service_api import send_event
+from .bios_settings_api import apply_pending_bios_settings
 from .response import success_response, simple_error_response, error_404_response, error_not_allowed_response
 
 members = {}
@@ -91,6 +92,7 @@ class ResetWorker(Thread):
         members[self.sys_id]['Oem']['Hpe']['PostState'] = 'InPost'
         send_power_event(self.sys_id, 'On')
         sleep(g.async_sleep)
+        apply_pending_bios_settings(self.sys_id)
         members[self.sys_id]['PowerState'] = 'On'
         members[self.sys_id]['Status']['State'] = 'Enabled'
         members[self.sys_id]['Oem']['Hpe']['PostState'] = 'InPostDiscoveryComplete'
@@ -110,6 +112,7 @@ class PowerOnWorker(Thread):
         members[self.sys_id]['Oem']['Hpe']['PostState'] = 'InPost'
         send_power_event(self.sys_id, 'On')
         sleep(g.async_sleep)
+        apply_pending_bios_settings(self.sys_id)
         members[self.sys_id]['PowerState'] = 'On'
         members[self.sys_id]['Status']['State'] = 'Enabled'
         members[self.sys_id]['Oem']['Hpe']['PostState'] = 'InPostDiscoveryComplete'


### PR DESCRIPTION
Previously, PATCH to /Systems/{id}/Bios/Settings updated the pending settings resource but never affected the live /Systems/{id}/Bios resource, so BIOS changes appeared instantly instead of after a reboot.

- Add apply_pending_bios_settings(sys_id) in bios_settings_api.py, which merges pending Attributes into the live Bios resource and then clears the pending diff by resyncing Bios/Settings to the newly-applied values (matches real hardware, which leaves Settings diff-free after a successful apply rather than re-applying stale changes on the next boot).
- Wire the helper into ResetWorker.run() and PowerOnWorker.run() in computer_system_api.py so it fires once emulated POST completes, for GracefulRestart, ForceRestart, PushPowerButton, On, and ForceOn.