### PR TITLE
Reject redundant ComputerSystem.Reset power actions

### DIFF
--- a/src/api_emulator/redfish/computer_system_api.py
+++ b/src/api_emulator/redfish/computer_system_api.py
@@ -50,7 +50,7 @@ import g
 from .redfish_auth import auth, Privilege
 from .event_generator import GenEvent, GenEventRecord
 from .event_service_api import send_event
-from .response import success_response, simple_error_response, error_404_response, error_not_allowed_response
+from .response import success_response, simple_error_response, error_404_response, error_not_allowed_response, error_invalid_operation_for_system_state_response
 
 members = {}
 members_actions = {}
@@ -262,6 +262,7 @@ class ResetAction_API(Resource):
                         if members_reset_thread[ident] is not None and members_reset_thread[ident].is_alive():
                             # Ignore other power actions if we have a pending thread.
                             logging.info('Thread is running. Ignoring request')
+                            resp = members[ident], 200
                         elif value in reboot_actions:
                             if state == 'On':
                                 logging.info('Starting reset thread')
@@ -271,16 +272,28 @@ class ResetAction_API(Resource):
                                 logging.info('Reset action with current PowerState Off. Starting reset thread')
                                 members_reset_thread[ident] = PowerOnWorker(ident)
                                 members_reset_thread[ident].start()
+                            resp = members[ident], 200
                         elif value in off_actions:
-                            logging.info('Powering Off')
-                            members[ident]['PowerState'] = 'Off'
-                            members[ident]['Status']['State'] = 'Disabled'
-                            members[ident]['Oem']['Hpe']['PostState'] = 'PowerOff'
+                            if state == 'Off':
+                                logging.info('Reject: already Off')
+                                resp = error_invalid_operation_for_system_state_response('Power is off')
+                            else:
+                                logging.info('Powering Off')
+                                members[ident]['PowerState'] = 'Off'
+                                members[ident]['Status']['State'] = 'Disabled'
+                                members[ident]['Oem']['Hpe']['PostState'] = 'PowerOff'
+                                resp = members[ident], 200
                         elif value in on_actions:
-                            logging.info('Starting reset thread')
-                            members_reset_thread[ident] = PowerOnWorker(ident)
-                            members_reset_thread[ident].start()
-                        resp = members[ident], 200
+                            if state == 'On':
+                                logging.info('Reject: already On')
+                                resp = error_invalid_operation_for_system_state_response('Power is on')
+                            else:
+                                logging.info('Starting reset thread')
+                                members_reset_thread[ident] = PowerOnWorker(ident)
+                                members_reset_thread[ident].start()
+                                resp = members[ident], 200
+                        else:
+                            resp = members[ident], 200
                     else:
                         resp = simple_error_response('Invalid ResetType', 400)
                 else:

--- a/src/api_emulator/redfish/response.py
+++ b/src/api_emulator/redfish/response.py
@@ -18,6 +18,25 @@ def simple_error_response(msg, status, jsonify=False):
         data = json.dumps(data, indent=4)
     return data, status
 
+def error_invalid_operation_for_system_state_response(message_arg, jsonify=False):
+    data = {
+        "error": {
+            "code": "iLO.0.10.ExtendedInfo",
+            "message": "See @Message.ExtendedInfo for more information.",
+            "@Message.ExtendedInfo": [
+                {
+                    "MessageArgs": [
+                        "{}".format(message_arg)
+                    ],
+                    "MessageId": "iLO.2.25.InvalidOperationForSystemState"
+                }
+            ]
+        }
+    }
+    if jsonify:
+        data = json.dumps(data, indent=4)
+    return data, 400
+
 def error_400_response(jsonify=False):
     data = {
         "error": {


### PR DESCRIPTION
Real HPE iLO rejects power actions that don't make sense given the current PowerState (e.g. powering on a system that is already on), returning iLO.2.25.InvalidOperationForSystemState. The emulator previously accepted these no-op requests unconditionally.

- Add error_invalid_operation_for_system_state_response() in response.py, matching iLO's iLO.0.10.ExtendedInfo error envelope with a configurable MessageArgs value.
- In ResetAction_API.post() (computer_system_api.py), reject On with "Power is on" when already On, and reject Off/ForceOff/GracefulShutdown/Nmi with "Power is off" when already Off. Reboot actions and the existing "reset thread already running" behavior are unchanged.

Verified against a running emulator instance: On-while-On and ForceOff-while-Off both return HTTP 400 with the expected message; normal Off->On, On->Off, and ForceRestart-while-On transitions still succeed as before.